### PR TITLE
Adds error param to function

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const get = httpProvider => {
         .then(() => {
           resolve(web3);
         })
-        .catch(() => {
+        .catch((error) => {
           reject(error);
         });
     } else if (window.web3) {


### PR DESCRIPTION
The catch block in the window.ethereum.enable() function is missing the error param.